### PR TITLE
Rename APP_PATH to EXPORT_PATH and re-use it

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-APP_PATH=/path/to/spotify-ripper-web/
+EXPORT_PATH=/path/to/ripped_music

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,10 +9,10 @@ services:
     ports:
       - "80:3000"
       - "81:3300"
-      
+
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./ripped_music:/ripped_music
+      - ${EXPORT_PATH}:/ripped_music
 
     environment:
-      APP_PATH: ${APP_PATH}
+      EXPORT_PATH: ${EXPORT_PATH}

--- a/spotify-ripper-web-backend/socket/packets/incoming/start-ripper.js
+++ b/spotify-ripper-web-backend/socket/packets/incoming/start-ripper.js
@@ -102,7 +102,7 @@ module.exports = {
     console.log("Trying to download..", "User", packet.data.user);
 
     const folderName = (new Date().getTime()).toString(36);
-    const folderPath = `${process.env.APP_PATH}/ripped_music/${ folderName }`;
+    const folderPath = `${process.env.EXPORT_PATH}/${ folderName }`;
 
     const containerOptions = {
       ...baseContainerOptions,


### PR DESCRIPTION
I think the original `APP_PATH` was a bit confusing - it was not really where the APP was living but was more about where the files will be downloaded to.

As you needed to set the absolute path in the `.env` anyway, have changed the config across the app to rely on replacement variable, `EXPORT_PATH`, which only needs to be configured once in the `.env` file. It will then get re-used in the docker-compose.